### PR TITLE
Fix: Handle absolute and relative paths correctly

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -13,50 +13,47 @@
 // TODO: should probably be in a commons file or whatever
 static std::string readFileAsText(const std::string& path) {
     std::ifstream ifs(path);
-    if (!ifs) {
+    if (!ifs)
         throw std::runtime_error("Could not open file: " + path);
-    }
 
     auto res = std::string((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
 
-    if (!res.empty() && res.back() == '\n') {
+    if (!res.empty() && res.back() == '\n')
         res.pop_back();
-    }
+
 
     return res;
 }
 
 CConfig::CConfig() {
-    std::string user_config_path_str = g_pGlobalState->configPath;
+    std::string userConfigPathStr = g_pGlobalState->configPath;
 
-    std::filesystem::path user_config_path = user_config_path_str;
+    std::filesystem::path userConfigPath = userConfigPathStr;
 
-    std::filesystem::path final_config_path;
-    if (user_config_path.is_absolute()) {
-        final_config_path = user_config_path;
-    } else {
-
-        final_config_path = std::filesystem::path(g_pGlobalState->cwd) / user_config_path;
-    }
+    std::filesystem::path finalConfigPath;
+    if (userConfigPath.is_absolute())
+        finalConfigPath = userConfigPath;
+    else
+        finalConfigPath = std::filesystem::path(g_pGlobalState->cwd) / userConfigPath;
 
     std::error_code ec;
-    final_config_path = std::filesystem::canonical(final_config_path, ec);
-    if (ec) {
-       throw std::runtime_error("Error resolving config path: " + final_config_path.string() + " - " + ec.message());
-    }
+    finalConfigPath = std::filesystem::canonical(finalConfigPath, ec);
+    if (ec)
+        throw std::runtime_error("Error resolving config path: " + finalConfigPath.string() + " - " + ec.message());
 
-    std::string config_content;
+
+    std::string configContent;
     try {
-        config_content = readFileAsText(final_config_path.string());
+        configContent = readFileAsText(finalConfigPath.string());
     } catch (const std::runtime_error& e) {
-        throw std::runtime_error("Failed to read configuration file '" + final_config_path.string() + "': " + e.what());
+        throw std::runtime_error("Failed to read configuration file '" + finalConfigPath.string() + "': " + e.what());
     }
 
-    auto json = glz::read_jsonc<SConfig>(config_content);
+    auto jsonConfig = glz::read_jsonc<SConfig>(configContent);
 
-    if (!json.has_value()) {
-        throw std::runtime_error("No config / bad config format in file: " + final_config_path.string());
-    }
+    if (!jsonConfig.has_value())
+        throw std::runtime_error("No config / bad config format in file: " + finalConfigPath.string());
 
-    m_config = json.value();
+
+    m_config = jsonConfig.value();
 }

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -1,22 +1,62 @@
 #include "Config.hpp"
 
 #include <glaze/glaze.hpp>
+#include <filesystem>
+#include <string>
+#include <stdexcept>
+#include <fstream>
+#include <fstream>
+
 
 #include "../GlobalState.hpp"
 
+// TODO: should probably be in a commons file or whatever
 static std::string readFileAsText(const std::string& path) {
     std::ifstream ifs(path);
-    auto          res = std::string((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
-    if (res.back() == '\n')
+    if (!ifs) {
+        throw std::runtime_error("Could not open file: " + path);
+    }
+
+    auto res = std::string((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+
+    if (!res.empty() && res.back() == '\n') {
         res.pop_back();
+    }
+
     return res;
 }
 
 CConfig::CConfig() {
-    auto json = glz::read_jsonc<SConfig>(readFileAsText(g_pGlobalState->cwd + "/" + g_pGlobalState->configPath));
+    std::string user_config_path_str = g_pGlobalState->configPath;
 
-    if (!json.has_value())
-        throw std::runtime_error("No config / bad config format");
+    std::filesystem::path user_config_path = user_config_path_str;
+
+    std::filesystem::path final_config_path;
+    if (user_config_path.is_absolute()) {
+        final_config_path = user_config_path;
+    } else {
+
+        final_config_path = std::filesystem::path(g_pGlobalState->cwd) / user_config_path;
+    }
+
+    std::error_code ec;
+    final_config_path = std::filesystem::canonical(final_config_path, ec);
+    if (ec) {
+       throw std::runtime_error("Error resolving config path: " + final_config_path.string() + " - " + ec.message());
+    }
+
+    std::string config_content;
+    try {
+        config_content = readFileAsText(final_config_path.string());
+    } catch (const std::runtime_error& e) {
+        throw std::runtime_error("Failed to read configuration file '" + final_config_path.string() + "': " + e.what());
+    }
+
+    auto json = glz::read_jsonc<SConfig>(config_content);
+
+    if (!json.has_value()) {
+        throw std::runtime_error("No config / bad config format in file: " + final_config_path.string());
+    }
 
     m_config = json.value();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv, char** envp) {
 
     std::vector<std::string> command;
 
-    g_pGlobalState->cwd = std::filesystem::current_path();
+    g_pGlobalState->cwd = std::filesystem::current_path().string();
 
     for (int i = 1; i < argc; ++i) {
         if (ARGS[i].starts_with("-")) {


### PR DESCRIPTION
Use `std::filesystem::is_absolute` to check paths from config for `html_dir`, `data_dir`, and `configPath` itself, resolving relative paths against CWD. Fixes #2