### PR TITLE
Handle any resource, determine Content-Type with libmagic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ add_compile_definitions(CHECKPOINT_VERSION="${CHECKPOINT_VERSION}")
 
 find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(deps IMPORTED_TARGET openssl re2)
+pkg_check_modules(deps IMPORTED_TARGET openssl re2 libmagic)
 
 target_include_directories(checkpoint
 PRIVATE

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you are using this, it's almost certain search engines will stop indexing you
 
 ## Setup guide
 
-1. Clone and build this repo. You will need `openssl`, `g++>=12`, `re2`, and deps for `pistache`, `fmt` and `tinylates`.
+1. Clone and build this repo. You will need `openssl`, `g++>=12`, `re2`, `libmagic`, and deps for `pistache`, `fmt` and `tinylates`.
 2. Create a `config.jsonc`. An example one is in `example/`.
 3. Adjust the config to your needs. Options are documented with comments in the example config.
 4. Set up your IP rules if you want. These allow you to set up IPs that are automatically blocked, or allowed to access without a challenge. This is useful for e.g. search engine scrapers. Some IP ranges can be found in `example/index_bots.jsonc`.

--- a/src/core/Handler.cpp
+++ b/src/core/Handler.cpp
@@ -93,7 +93,7 @@ std::string CServerHandler::fingerprintForRequest(const Pistache::Http::Request&
 }
 
 bool CServerHandler::isResourceCheckpoint(const std::string_view& res) {
-    return res == "/checkpoint/NotoSans.woff";
+    return res.starts_with("/checkpoint/");
 }
 
 std::string CServerHandler::ipForRequest(const Pistache::Http::Request& req) {


### PR DESCRIPTION
Don't hardcode allowed resource to specific resource, handle anything under /checkpoint/ incase user wants to customize the html and pull in arbitrary files.