### PR TITLE
Pass domain to HTML template

### DIFF
--- a/src/core/Handler.cpp
+++ b/src/core/Handler.cpp
@@ -6,6 +6,7 @@
 #include "../headers/cfHeader.hpp"
 #include "../headers/xforwardfor.hpp"
 #include "../headers/gitProtocolHeader.hpp"
+#include "../headers/wwwAuthenticateHeader.hpp"
 #include "../headers/acceptLanguageHeader.hpp"
 #include "../headers/setCookieHeader.hpp"
 #include "../headers/xrealip.hpp"
@@ -130,6 +131,7 @@ void CServerHandler::onRequest(const Pistache::Http::Request& req, Pistache::Htt
     std::shared_ptr<const XForwardedForHeader>                 xForwardedForHeader;
     std::shared_ptr<const AuthorizationHeader>                 authHeader;
     std::shared_ptr<const GitProtocolHeader>                   gitProtocolHeader;
+    std::shared_ptr<const WwwAuthenticateHeader>               wwwAuthenticateHeader;
 
     try {
         hostHeader = Pistache::Http::Header::header_cast<Pistache::Http::Header::Host>(HEADERS.get("Host"));
@@ -171,6 +173,12 @@ void CServerHandler::onRequest(const Pistache::Http::Request& req, Pistache::Htt
 
     try {
         gitProtocolHeader = Pistache::Http::Header::header_cast<GitProtocolHeader>(HEADERS.get("Git-Protocol"));
+    } catch (std::exception& e) {
+        ; // silent ignore
+    }
+
+    try {
+        wwwAuthenticateHeader = Pistache::Http::Header::header_cast<WwwAuthenticateHeader>(HEADERS.get("Www-Authenticate"));
     } catch (std::exception& e) {
         ; // silent ignore
     }

--- a/src/core/Handler.cpp
+++ b/src/core/Handler.cpp
@@ -362,11 +362,16 @@ void CServerHandler::serveStop(const Pistache::Http::Request& req, Pistache::Htt
     const auto NONCE     = generateNonce();
     const auto CHALLENGE = CChallenge(fingerprintForRequest(req), NONCE, difficulty);
 
+    auto hostDomain = req.headers().getRaw("Host").value();
+    if (hostDomain.contains(":"))
+            hostDomain = hostDomain.substr(0, hostDomain.find(':'));
+
     page.add("challengeDifficulty", CTinylatesProp(std::to_string(difficulty)));
     page.add("challengeNonce", CTinylatesProp(NONCE));
     page.add("challengeSignature", CTinylatesProp(CHALLENGE.signature()));
     page.add("challengeFingerprint", CTinylatesProp(CHALLENGE.fingerprint()));
     page.add("challengeTimestamp", CTinylatesProp(CHALLENGE.timestampAsString()));
+    page.add("hostDomain", CTinylatesProp(hostDomain));
     page.add("checkpointVersion", CTinylatesProp(CHECKPOINT_VERSION));
     response.send(Pistache::Http::Code::Ok, page.render().value_or("error"));
 }

--- a/src/core/Handler.cpp
+++ b/src/core/Handler.cpp
@@ -210,7 +210,11 @@ void CServerHandler::onRequest(const Pistache::Http::Request& req, Pistache::Htt
         // TODO: ratelimit this, probably.
 
         const auto RES        = req.resource();
-        bool validGitResource = RES.ends_with("/info/refs") || RES.ends_with("/info/packs") || RES.ends_with("HEAD") || RES.ends_with(".git") || RES.ends_with("/git-upload-pack");
+        bool validGitResource =
+		RES.ends_with("/info/refs") || RES.ends_with("/info/packs") ||
+		RES.ends_with("HEAD") || RES.ends_with(".git") ||
+		RES.ends_with("/git-upload-pack") ||
+		RES.ends_with("/git-receive-pack");
 
         if (RES.contains("/objects/")) {
             const std::string_view repo = std::string_view{RES}.substr(0, RES.find("/objects/"));

--- a/src/headers/wwwAuthenticateHeader.hpp
+++ b/src/headers/wwwAuthenticateHeader.hpp
@@ -1,0 +1,24 @@
+#include <pistache/http_headers.h>
+#include <pistache/net.h>
+
+class WwwAuthenticateHeader : public Pistache::Http::Header::Header {
+  public:
+    NAME("Www-Authenticate");
+
+    WwwAuthenticateHeader() = default;
+
+    void parse(const std::string& str) override {
+        m_text = str;
+    }
+
+    void write(std::ostream& os) const override {
+        os << m_text;
+    }
+
+    std::string text() const {
+        return m_text;
+    }
+
+  private:
+    std::string m_text = "";
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "headers/xforwardfor.hpp"
 #include "headers/cfHeader.hpp"
 #include "headers/gitProtocolHeader.hpp"
+#include "headers/wwwAuthenticateHeader.hpp"
 #include "headers/acceptLanguageHeader.hpp"
 #include "headers/setCookieHeader.hpp"
 #include "headers/xrealip.hpp"
@@ -81,6 +82,7 @@ int main(int argc, char** argv, char** envp) {
     Pistache::Http::Header::Registry::instance().registerHeader<CFConnectingIPHeader>();
     Pistache::Http::Header::Registry::instance().registerHeader<XForwardedForHeader>();
     Pistache::Http::Header::Registry::instance().registerHeader<GitProtocolHeader>();
+    Pistache::Http::Header::Registry::instance().registerHeader<WwwAuthenticateHeader>();
     Pistache::Http::Header::Registry::instance().registerHeader<AcceptLanguageHeader>();
     Pistache::Http::Header::Registry::instance().registerHeader<SetCookieHeader>();
     Pistache::Http::Header::Registry::instance().registerHeader<XRealIPHeader>();


### PR DESCRIPTION
This passes along the domain being accessed as a variable, which is useful for those who choose to customize the HTML.